### PR TITLE
fix: check the verbose flag for log queries

### DIFF
--- a/packages/sequelize-aws-data-api/lib/DataApiQuery.ts
+++ b/packages/sequelize-aws-data-api/lib/DataApiQuery.ts
@@ -16,7 +16,7 @@ export class DataApiQuery extends AbstractQuery {
   }
 
   run(sql: string, parameters: any []): any {
-    console.log(sql, parameters);
+    this.connection.log(sql, parameters);
     return this.connection.query(sql, parameters).then((result: CommonResult) => {
       // @ts-ignore
       if (this.isInsertQuery(sql) || this.isUpdateQuery(sql)) {


### PR DESCRIPTION
The this.connection.log function checks the options.verbose before output to the console